### PR TITLE
Fix Firefox date parsing for non US locale

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -150,7 +150,7 @@ class App extends Component {
               { this.state.result &&
                   <div className="ResultContent Flex Stack">
                     <div>In <b>{this.state.resultDays}</b> working days it will be:</div>
-                    <div className="Date">{moment(this.state.result).format('dddd, MMMM Do YYYY')}</div>
+                    <div className="Date">{moment(this.state.result, 'MM-DD-YYYY').format('dddd, MMMM Do YYYY')}</div>
                     <div className="Date">{this.state.result}</div>
                   </div>
               }


### PR DESCRIPTION
This resolves the date being displayed as an invalid date in Firefox due to ambiguous date format. 

![image](https://user-images.githubusercontent.com/32785419/31583476-4a1725d0-b1f9-11e7-8155-8fb3faaf92e3.png)
